### PR TITLE
Less verbose message in console on failure

### DIFF
--- a/detect-new-secrets.sh
+++ b/detect-new-secrets.sh
@@ -8,11 +8,33 @@ scan_new_secrets() {
     jq 'map(select(.category == "UNVERIFIED"))' "$all_secrets_file" > "$new_secrets_file"
 }
 
+advice_if_none_are_secret_short() {
+    cat << EOF
+### If none of these are secrets
+Update the file \`$BASELINE_FILE\`. For an updated version of this file with new secrets marked ok, visit the jobs summary for this action.
+EOF
+}
+
+advice_if_none_are_secret_verbose() {
+    baseline_with_all_secrets_marked_ok=$(jq 'setpath(["results"]; (.results | map_values(. | map_values(setpath(["is_secret"]; (.is_secret // false))))))' "$BASELINE_FILE")
+
+    cat << EOF
+### If none of these are secrets
+Replace the file `$BASELINE_FILE` with:
+
+<details>
+    <summary>Updated Secrets Baseline</summary>
+
+\`\`\`json
+$baseline_with_all_secrets_marked_ok
+\`\`\`
+</details>
+EOF
+}
+
 markdown_from_new_secrets() {
     secrets_table_body_with_json_chars=$(jq -r '.[] | "|\(.filename)|\(.lines | keys)|\(.types)|"' "$new_secrets_file")
     secret_table_body=$(echo "$secrets_table_body_with_json_chars" | tr -d '"' | tr -d ']'| tr -d '[')
-
-    baseline_with_all_secrets_marked_ok=$(jq 'setpath(["results"]; (.results | map_values(. | map_values(setpath(["is_secret"]; (.is_secret // false))))))' "$BASELINE_FILE")
 
     cat << EOF
 # Secret Scanner Report
@@ -27,18 +49,6 @@ Secrets pushed to GitHub are not safe to use.
 
 For the secrets you have just compromised (it is NOT sufficient to rebase to remove the commit), you should:
 * Rotate the secret
-
-### If none of these are secrets
-Replace the file \`.secrets.baseline\` with:
-
-<details>
-    <summary>Updated Secrets Baseline</summary>
-
-\`\`\`json
-$baseline_with_all_secrets_marked_ok
-\`\`\`
-</details>
-
 EOF
 }
 
@@ -49,5 +59,16 @@ if [ "$(cat $new_secrets_file)" = "[]" ]; then
     echo "No secrets found"
     exit 0
 fi
-markdown_from_new_secrets | tee "$GITHUB_STEP_SUMMARY"
+
+markdown_limited_advice=$(markdown_from_new_secrets)
+markdown_console_advice=$(advice_if_none_are_secret_short)
+
+# Print a short message to the console
+echo "$markdown_limited_advice"
+echo "$markdown_console_advice"
+
+# Write a more detailed message to the jobs summary
+echo "$markdown_limited_advice" > "$GITHUB_STEP_SUMMARY"
+advice_if_none_are_secret_verbose >> "$GITHUB_STEP_SUMMARY"
+
 exit 1


### PR DESCRIPTION
This PR solves two problems:
1. Previously, the messaging left in the console + jobs summary referenced the file `.secrets.baseline`. If a repo is using a secrets file that is NOT called `.secrets.baseline`, then this would have been very confusing.
2. Previously, I was dumping an updated `.secrets.baseline` in the console. For larger repos, this file is quite large and it takes some time to scroll to the top so that you can see the list of secrets. Given that we are also printing this information in the jobs summary, we do not need to print it in the console as well.