### PR TITLE
Fix new secret scanning

### DIFF
--- a/detect-new-secrets.sh
+++ b/detect-new-secrets.sh
@@ -3,7 +3,7 @@ all_secrets_file=$(mktemp)
 new_secrets_file=$(mktemp)
 
 scan_new_secrets() {
-    git ls-files -z | xargs -0 detect-secrets scan $DETECT_SECRET_ADDITIONAL_ARGS --baseline "$BASELINE_FILE"
+    detect-secrets scan $DETECT_SECRET_ADDITIONAL_ARGS --baseline "$BASELINE_FILE"
     detect-secrets audit "$BASELINE_FILE" --report --json > "$all_secrets_file"
     jq 'map(select(.category == "UNVERIFIED"))' "$all_secrets_file" > "$new_secrets_file"
 }


### PR DESCRIPTION
# Fix Detect secret scanning
There are two ways to look for new secrets based on the README for `Yelp/detect-secrets`. In this Github action, I managed to combine both together. While the combination mostly works, I have a (private) PR where it did not behave as expected. The two ways to do this are:

## Using `detect-secrets`
```
detect-secrets scan --baseline .secrets.baseline
```

## Using `detect-secrets-hook`
```
git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
```
This approach has the benefit of mutating `.secrets.baseline`, which makes it easier to generate the new file.

I managed to combine these two approaches into:
```
git ls-files -z | xargs -0 detect-secrets scan $DETECT_SECRET_ADDITIONAL_ARGS --baseline "$BASELINE_FILE"
```

Testing locally, it seems that `detect-secrets` is much faster, but when I get around to implementing https://github.com/secret-scanner/action/issues/6 I will switch to `detect-secrets-hook`.