### PR TITLE
Consistantly using underscore in inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ jobs:
       - name: Secret Scanner
         uses: secret-scanner/action@0.0.2
         with:
-          detect-secret-additional-args: ${{ env.SCANNER_ARGS }}
+          detect_secret_additional_args: ${{ env.SCANNER_ARGS }}
 ```
 
 This will ignore everything in `.github/actions/spelling/*`, and any line that matches the regex `^\s+with\s+imageTag\s*=.*$`.
@@ -101,8 +101,8 @@ This will ignore everything in `.github/actions/spelling/*`, and any line that m
 ### Inputs
 |Input|Description|Required|default value|
 |-----|-----------|--------|-------------|
-|detect-secrets-version|The version of Yelp/detect-secrets to use|no|1.2.0|
-|detect-secret-additional-args|Extra arguments to pass to the `detect-secret` binary when it is looking for secrets|no|No additional arguments (empty string)|
-|baseline-file|A path to the baseline secrets file|no|.secrets.baseline|
-|python-version|The version of python to use|no|3.10.4|
+|detect_secrets_version|The version of Yelp/detect-secrets to use|no|1.2.0|
+|detect_secret_additional_args|Extra arguments to pass to the `detect-secret` binary when it is looking for secrets|no|No additional arguments (empty string)|
+|baseline_file|A path to the baseline secrets file|no|.secrets.baseline|
+|python_version|The version of python to use|no|3.10.4|
 |exclude_files_path|A path to the files containing things to exclude|no|.github/actions/secret-scanner|

--- a/action.yml
+++ b/action.yml
@@ -6,19 +6,19 @@ branding:
   color: 'orange'
 
 inputs:
-  detect-secrets-version:
+  detect_secrets_version:
     description: 'The version of Yelp/detect-secrets to use'
     required: false
     default: '1.2.0'
-  detect-secret-additional-args:
+  detect_secret_additional_args:
     description: 'Extra arguments to pass to the detect-secret binary'
     required: false
     default: ''
-  baseline-file:
+  baseline_file:
     description: "A path to the baseline secrets file"
     required: false
     default: .secrets.baseline
-  python-version:
+  python_version:
     description: "The version of python to use"
     required: false
     default: '3.10.4'
@@ -33,18 +33,18 @@ runs:
     - name: Set-up python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python_version }}
     - name: Install detect-secrets
       shell: bash
       run: pip install detect-secrets[gibberish]=="$DETECT_SECRET_VERSION"
       env: 
-        DETECT_SECRET_VERSION: ${{ inputs.detect-secrets-version }}
+        DETECT_SECRET_VERSION: ${{ inputs.detect_secrets_version }}
     - name: Check for secrets
       shell: bash
       run: $GITHUB_ACTION_PATH/detect-new-secrets.sh
       env:
-        BASELINE_FILE: ${{ inputs.baseline-file }}
-        DETECT_SECRET_ADDITIONAL_ARGS: ${{ inputs.detect-secret-additional-args }}
+        BASELINE_FILE: ${{ inputs.baseline_file }}
+        DETECT_SECRET_ADDITIONAL_ARGS: ${{ inputs.detect_secret_additional_args }}
         EXCLUDE_FILES_PATH: ${{ inputs.exclude_files_path }}/excluded_files.patterns
         EXCLUDE_SECRETS_PATH: ${{ inputs.exclude_files_path }}/excluded_secrets.patterns
         EXCLUDE_LINES_PATH: ${{ inputs.exclude_files_path }}/excluded_lines.patterns


### PR DESCRIPTION
Previously, some inputs separated words with underscores while others used dashes. We will now use underscores consistently.

While doing this would generally be bad practice, as it breaks backwards compatibility for very little benefit, in practice the only ones who are currently using this GitHub action is Garnercorp which I can fix myself.