### PR TITLE
Fixing command on zsh

### DIFF
--- a/detect-new-secrets.sh
+++ b/detect-new-secrets.sh
@@ -42,16 +42,11 @@ EOF
 
 generate_command_to_update_secrets_baseline() {
     cat << EOF > "$command_to_update_baseline_file"
-currently_staged_files=\`git diff --name-only --cached\`
-git reset HEAD
+cat << 'NEW_BASELINE' > "$BASELINE_FILE"
+$(jq 'setpath(["results"]; (.results | map_values(. | map_values(setpath(["is_secret"]; (.is_secret // false))))))' "$BASELINE_FILE")
+NEW_BASELINE
 
-echo '$(jq 'setpath(["results"]; (.results | map_values(. | map_values(setpath(["is_secret"]; (.is_secret // false))))))' "$BASELINE_FILE")' > "$BASELINE_FILE"
-git add "$BASELINE_FILE"
-git commit -m "Updating baseline file"
-
-if [ "\$currently_staged_files" ]; then
-    git add $currently_staged_files
-fi
+git commit -m "Updating baseline file" "$BASELINE_FILE"
 EOF
 }
 


### PR DESCRIPTION
# The problem
The suggested script was not working for `zsh` users. This is because of the different ways that `\\` is interpreted between bash and zsh users.

```
# BASH
$ echo '\\'
\\

# ZSH
$ echo '\\'
\
```

# How the problem was fixed
Switched from using an `echo` to using a `heredoc` wrapped in single quotes. This behaves the same way between `bash` + `zsh`

# Notes
Previously the script was:
1. Getting a list of all the staged files
2. Unstaging everything
3. Updating `.secrets.baseline` and committing it
4. Restaging everything from `1`

@jsoref pointed out to me that I can accomplish the same thing more simply with a `git commit -m '<some-message>' '<some-file>'` so I have switched to doing this instead

# Testing done
1. In bash, ran the old + new generated scripts generated from a commit with the same newly added secret and asserted the the resulting `.secrets.baseline` would be the same for both
2. Checked that the heredoc works the same on zsh + bash