### PR TITLE
Don't log if a regex file DNE

### DIFF
--- a/detect-new-secrets.sh
+++ b/detect-new-secrets.sh
@@ -8,12 +8,12 @@ fetch_flags_from_file() {
     file_to_check="$2"
     
     flags=()
-    while read line; do 
+    (while read line; do 
         if [[ "${line::1}" != '#' ]] && [[ ! -z "$line" ]]; then
             flag="$flag_to_add $line "
             flags+="$flag"
         fi
-    done < "$file_to_check"
+    done < "$file_to_check") 2>&1 > /dev/null
 
     echo "$flags"
 }


### PR DESCRIPTION
# The problem
If one of the regex excludes files DNE, we were getting a log in `stderr` saying that it could not find the file

# The solution
Since I do not care about the output of anything in the while loop, I am sending its `stderr` + `stdout` to `/dev/null`