### PR TITLE
Make it easier to run locally

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,13 +1,17 @@
 args
+dirname
 json
 mktemp
 NONINFRINGEMENT
+pwd
 README
 regex
 regexp
 setpath
+stderr
 ubuntu
 URL
+usr
 workflow
 yaml
 yml

--- a/detect-new-secrets.sh
+++ b/detect-new-secrets.sh
@@ -1,7 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 all_secrets_file=$(mktemp)
 new_secrets_file=$(mktemp)
 command_to_update_baseline_file=$(mktemp)
+if [ -z "$GITHUB_ACTION_PATH" ]; then
+    GITHUB_ACTION_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+fi
+GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-/dev/stderr}
 
 fetch_flags_from_file() {
     flag_to_add="$1"

--- a/detect-new-secrets.sh
+++ b/detect-new-secrets.sh
@@ -5,7 +5,7 @@ command_to_update_baseline_file=$(mktemp)
 if [ -z "$GITHUB_ACTION_PATH" ]; then
     GITHUB_ACTION_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 fi
-GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-/dev/stderr}
+GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-'/dev/stderr'}
 
 fetch_flags_from_file() {
     flag_to_add="$1"


### PR DESCRIPTION
I was testing by just running the script locally (w/o [`act`](https://github.com/nektos/act)), and it was handy to basically just run the script.

This also changes the `bash` that's running to the `bash` that's in the `$PATH`. On macOS the system `bash` is `3.2`, but the script is designed to run on Linux where `bash` will be `5.x`+.